### PR TITLE
Fix Brotli compressor buffer bounds check

### DIFF
--- a/src/lib/brotli.inc.c
+++ b/src/lib/brotli.inc.c
@@ -39,7 +39,8 @@ static uint32_t my_crc32(const uint8_t *data, size_t len, uint32_t crc) {
 }
 
 static size_t simple_compress(const uint8_t *input, size_t input_len, uint8_t *output, size_t output_len) {
-	if (output_len < input_len + 8) {
+	const size_t header_size = 5 + 8 + 4;
+	if (output_len < header_size || input_len > output_len - header_size) {
 		return 0;
 	}
 	memcpy (output, "BROT", 4);
@@ -54,7 +55,7 @@ static size_t simple_compress(const uint8_t *input, size_t input_len, uint8_t *o
 }
 
 static size_t simple_decompress(const uint8_t *input, size_t input_len, uint8_t *output, size_t output_len) {
-	if (input_len < 5 + sizeof (size_t) + sizeof (uint32_t)) {
+	if (input_len < 5 + 8 + 4) {
 		return 0;
 	}
 	if (memcmp (input, "BROT", 4) != 0) {
@@ -69,7 +70,7 @@ static size_t simple_decompress(const uint8_t *input, size_t input_len, uint8_t 
 		return 0;
 	}
 	uint32_t stored_crc = otezip_read_le32 (input + 5 + 8);
-	const uint8_t *data = input + 5 + sizeof (size_t) + sizeof (uint32_t);
+	const uint8_t *data = input + 5 + 8 + 4;
 	uint32_t computed_crc = my_crc32 (data, stored_len, 0);
 	if (stored_crc != computed_crc) {
 		return 0;


### PR DESCRIPTION
### Motivation
- The Brotli shim wrote a 5-byte magic, an 8-byte length and a 4-byte CRC before the payload but only validated `output_len < input_len + 8`, which allowed out-of-bounds writes for slightly undersized output buffers.

### Description
- Introduce a fixed `header_size = 5 + 8 + 4` and validate capacity with `if (output_len < header_size || input_len > output_len - header_size)` in `simple_compress` to prevent overflow when writing the header and payload.
- Update `simple_decompress` minimum-input checks and payload offsets to use the same fixed-width header layout (`5 + 8 + 4`) so framing logic is consistent.
- Changes are confined to `src/lib/brotli.inc.c` and preserve the existing framing format and behavior for correctly-sized buffers.

### Testing
- Ran `make -j4` which built the main binary and library successfully.
- Ran `make -C test/unit` and unit binaries were built successfully; unit targets completed without errors.
- Ran `make -C test` which stopped during integration due to missing external tools (`xxd`, `file`, `7z`) in the environment, so integration script checks could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aab24e49b08331a547fcdb97cbf7fe)