### PR TITLE
Validate DEFLATE distance code range before table lookup

### DIFF
--- a/src/lib/deflate-dec.inc.c
+++ b/src/lib/deflate-dec.inc.c
@@ -762,6 +762,9 @@ int inflate(z_stream *strm, int flush) {
 					if (len > 15 || distance_code < 0) {
 						return Z_DATA_ERROR; /* Invalid Huffman code */
 					}
+					if (distance_code > 29) {
+						return Z_DATA_ERROR; /* Reserved distance codes 30-31 */
+					}
 					/* Convert to actual distance */
 					static const uint16_t dist_base[] = {
 						1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193, 257, 385, 513, 769, 1025, 1537, 2049, 3073, 4097, 6145, 8193, 12289, 16385, 24577


### PR DESCRIPTION
### Motivation
- Prevent an out-of-bounds read in the bundled DEFLATE decoder by rejecting reserved/invalid distance symbols (30–31) before they are used to index the `dist_base`/`dist_extra` tables.

### Description
- Add a single check in `src/lib/deflate-dec.inc.c` that returns `Z_DATA_ERROR` when `distance_code > 29`, keeping valid-stream behavior unchanged.

### Testing
- Ran `make`, which completed successfully.
- Ran `make -C test/unit run`, which executed the unit tests; the suite ran but some pre-existing tests (e.g., `test_mzip_deflate`) report logical failures unrelated to this change.
- Ran `make -C test`, which failed in this environment due to missing external tools (`xxd`, `file`, `7z`) used by the integration script.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aab2f8d6308331afa0bfb2175fe5e8)